### PR TITLE
Fix scanner's variables rule and precedence

### DIFF
--- a/plt_project/bin/scanner.mll
+++ b/plt_project/bin/scanner.mll
@@ -26,8 +26,6 @@ rule tokenize = parse
 | "==" { EQL }
 | "!=" { NOTEQL }
 | ';' { SEMICOLON }
-(* | ['0'-'9']+ as lit { LITERAL(int_of_string lit) } *)
-(* | letter (letter | digit | '_')* as id { VARIABLE( id ) } *)
 | "True" { BLIT(true) }
 | "False" { BLIT(false) }
 (* | '-'?digit+'.'digit (['e' 'E']['+' '-']? digit ) as fltlit { FLOATLIT(float_of_string fltlit) } *)
@@ -50,7 +48,10 @@ rule tokenize = parse
 | "EDGE" { EDGE }
 | "NOT" { NOT }
 | "WHILE" { WHILE }
-
+| "IF" { IF }
+| "ELSE" { ELSE }
+| "ELIF" { ELIF }
+| letter (letter | digit | '_')* as id { VARIABLE( id ) }
 | "," {COMMA}
 | "\"" {QUOTES}
 | "(" { LP }
@@ -62,8 +63,5 @@ rule tokenize = parse
 | "," { COMMA }
 | "-" { DASH }
 | "->" { ARROW }
-| "IF" { IF }
-| "ELSE" { ELSE }
-| "ELIF" { ELIF }
 | _ { raise (Failure "Character not allowed") }
 | "#" { COMMENT }


### PR DESCRIPTION
## Purpose
variables was only accepting lowercase strings, and was blocking keywords in scanner.

## Changes
1. Uncommented the correct rule for alphanumeric vars
2. Moved below all keywords in scanner

## Testing
Tested that `Vertex_ONE123` would be accepted: 

<img width="1142" alt="Screenshot 2024-05-01 at 3 59 00 PM" src="https://github.com/gtamer2/plt_project_graphsql/assets/13108692/7ac73567-6dbc-48aa-a974-a22649168b64">
<img width="338" alt="Screenshot 2024-05-01 at 3 58 54 PM" src="https://github.com/gtamer2/plt_project_graphsql/assets/13108692/b493a879-836e-40ac-a0d2-8573d99fdb96">
