### PR TITLE
Fix dash not working in edge creation

### DIFF
--- a/plt_project/bin/graph_init2.tb
+++ b/plt_project/bin/graph_init2.tb
@@ -1,7 +1,7 @@
 CREATE GRAPH (
 	[VERTEX (vertexone),
-	VERTEX (vertextwo),
-	EDGE (vertexone,vertextwo,10)
+	VERTEX (VERTEX_two9876),
+	EDGE (vertexone - vertextwo,10)
     ]
 ) AS g;
 g.edges

--- a/plt_project/bin/parser.mly
+++ b/plt_project/bin/parser.mly
@@ -15,7 +15,7 @@
 
 %token DOT 
 %token VERTEX EDGE VERTICES EDGES
-%token LP RP LB RB LC RC COMMA DASH ARROW QUOTES COMMENT
+%token LP RP LB RB LC RC COMMA ARROW QUOTES COMMENT
 %token GRAPH
 %token IF ELSE ELIF
 %token DEFINE FUNCTION
@@ -38,7 +38,7 @@
 
 graph_element:
     | VERTEX LP VARIABLE RP { Vertex($3) }
-    | EDGE LP VARIABLE COMMA VARIABLE COMMA LITERAL RP { Edge($3, $5, $7) }
+    | EDGE LP VARIABLE MINUS VARIABLE COMMA LITERAL RP { Edge($3, $5, $7) }
 
 graph_elements:
     | graph_element COMMA graph_elements { $1::$3 }

--- a/plt_project/bin/scanner.mll
+++ b/plt_project/bin/scanner.mll
@@ -60,7 +60,6 @@ rule tokenize = parse
 | "{" { LC }
 | "}" { RC }
 | "," { COMMA }
-| "-" { DASH }
 | "->" { ARROW }
 | _ { raise (Failure "Character not allowed") }
 | "#" { COMMENT }


### PR DESCRIPTION
## Purpose
DASH was not working in edge creation, we were using comma. 
The issue was that DASH is actually a duplicate token of MINUS in the scanner.

## Changes
- remove DASH from scanner
- replace COMMA with MINUS in parser edge creation

## Testing
The updated test works.